### PR TITLE
Update ProtocolExec.java

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProtocolExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProtocolExec.java
@@ -130,7 +130,7 @@ public final class ProtocolExec implements ExecChainHandler {
                     } else {
                         uri = URIUtils.rewriteURI(uri);
                     }
-                    request.setPath(uri.toASCIIString());
+                    request.setPath(uri.getPath());
                 } catch (final URISyntaxException ex) {
                     throw new ProtocolException("Invalid request URI: " + request.getRequestUri(), ex);
                 }


### PR DESCRIPTION
system: macOS 10.15.6

problem: I take `cookieStore` to manage my cookies, if I config the system's network, set a proxy, the cookies in the `cookieStore` won't sent to the website

the reason is the code I changed, before my change, the request's path will change to the all url, actually, the path should be the url's last part expect the host, like 'https://google.com/', the path should be '/', but if there have system proxy, the path will changed to 'http://google.com/', this will make cookie match mistake, so, it won't sent the cookie to the website